### PR TITLE
This commit fixes relative path issue (#4) by passing the file name with...

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -29,7 +29,8 @@ module.exports = function(file, opts, callback) {
 
     var compassExecutable = 'compass',
         file_name = path.basename(file),
-        file_path = file.replace(/\\/g, '/');
+        file_path = file.replace(/\\/g, '/'),
+        relative_file_name = file_path.replace(new RegExp(path.join(opts.project || process.cwd(), opts.sass)), '').slice(1);
 
     if (file_name.match(/^_/)) {
         return;
@@ -84,7 +85,7 @@ module.exports = function(file, opts, callback) {
     // support callback
     child.on('close', function(code) {
         var new_path;
-        new_path = path.join(opts.project, opts.css, file_name);
+        new_path = path.join(opts.project, opts.css, relative_file_name);
         callback && callback(code, stdout, stderr, new_path);
     });
 };


### PR DESCRIPTION
... relative path to the compass.js lib callback

This is a simple solution to this relative path issue. It just creates a new variable called `relative_file_path` containing the file name with path relative to sass directory.

Examples (considering that sass dir is `sass`):

| Folder | relative_file_name |
| --- | --- |
| sass/base/screen.scss | base/screen.scss |
| sass/base/components/buttons.scss | base/components/buttons.scss |

In the end, the callback is called with `relative_file_name` instead of `file_name`, this way there will be no exception thrown, solving the error described in (#4).
