### PR TITLE
Fix #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = function(opt){
                     'You need to have Ruby and Compass installed ' +
                     'and in your system PATH for this task to work. '));
             }
+            if (code === 42) {
+                // This is a partial, just drop it
+                return cb();
+            }
             // excute callback
             file.path = gutil.replaceExtension(file.path, '.css');
             file.contents = new Buffer(fs.readFileSync(String(gutil.replaceExtension(path, '.css'))));

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -34,6 +34,7 @@ module.exports = function(file, opts, callback) {
         relative_file_name = path.relative(path.join(opts.project || process.cwd(), opts.sass), file);
 
     if (file_name.match(/^_/)) {
+        callback && callback(42, '', '', '');
         return;
     }
 


### PR DESCRIPTION
This fixes the symptoms described in #2.

Pretty much, if there is a partial in the matched list, the compass helper (lib/compass) just drops out and never calls back: https://github.com/appleboy/gulp-compass/blob/master/lib/compass.js#L37 

The user can workaround this by avoiding selecting partials. That would go:

```
.src(['assets/scss/**.scss', '!**/_*.scss'])
```

This patch should fix it: do callback instead of silently dropping out, and then drop from the list instead.

Btw, I just discovered gulp, and I think I'm madly in love :-)
