### PR TITLE
Support watching files and other tasks, not only 'compile'

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -64,7 +64,7 @@ module.exports = function(file, opts, callback) {
     if (opts.bundle_exec) {
         options.push('exec', 'compass');
     }
-    options.push('compile');
+    options.push(opts.task || 'compile');
     if (process.platform === 'win32') {
         options.push(opts.project.replace(/\\/g, '/'));
     } else {


### PR DESCRIPTION
This way we can let compass watch the files itself, instead of relying that to gulp, so it can optimize what compiles again and what doesn't.