### PR TITLE
Avoid missing error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function(opt) {
 
             // support error callback
             if (code !== 0) {
-                this.emit('error', new gutil.PluginError(PLUGIN_NAME, stdout));
+                this.emit('error', new gutil.PluginError(PLUGIN_NAME, stdout || 'Compass failed'));
                 return cb();
             }
 


### PR DESCRIPTION
When `options.logging == false` and `compass` finishes unsuccessfully, `stdout` will be empty and be passed as `message` to construct `gutil.PluginError`, leading `gutil.PluginError` to throw an unexpected error ("Missing error message").

Fixed by providing a default error message.
