### PR TITLE
Fix garbled output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,13 @@ module.exports = function(opt) {
             }
 
             // excute callback
+            var pathToCss = gutil.replaceExtension(path, '.css')
+              , contents = fs.readFileSync(pathToCss);
+
+            if (!(contents instanceof Buffer)) { contents = new Buffer(contents) }; // Fix garbled output.
+
             file.path = gutil.replaceExtension(file.path, '.css');
-            file.contents = new Buffer(fs.readFileSync(String(gutil.replaceExtension(path, '.css'))));
+            file.contents = contents;
             this.push(file);
             cb();
         }.bind(this));


### PR DESCRIPTION
I've been having problems with getting garbled output from gulp-compass on Ubuntu 12.04 with Node 0.11.6. This small change, checking if the object returned from readFileSync is already a Buffer and not applying Buffer a second time, seems to fix that problem.
