### PR TITLE
No need to run set cwd to project path

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -109,7 +109,7 @@ module.exports = function(file, opts, callback) {
     gutil.log(PLUGIN_NAME + ':', 'Running command:', compassExecutable, options.join(' '));
   }
 
-  var child = spawn(compassExecutable, options, {cwd: opts.project || process.cwd()}),
+  var child = spawn(compassExecutable, options, {cwd: process.cwd()}),
     stdout = '',
     stderr = '';
   if (opts.logging) {


### PR DESCRIPTION
This should fix the `You must compile individual stylesheets from the project directory` error when specifying a `project` path.
