### PR TITLE
Allow passing of --generated-images-path to compass (fixes #37)

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -13,6 +13,7 @@ var PLUGIN_NAME = 'gulp-compass',
     sass: 'sass',
     image: false,
     generated_images_path: false,
+    http_path: false,
     javascript: false,
     font: false,
     import_path: false,
@@ -85,6 +86,7 @@ module.exports = function(file, opts, callback) {
   if (opts.style) { options.push('--output-style', opts.style); }
   if (opts.image) { options.push('--images-dir', opts.image); }
   if (opts.generated_images_path) { options.push('--generated-images-path', opts.generated_images_path); }
+  if (opts.http_path) { options.push('--http-path', opts.http_path); }
   if (opts.javascript) { options.push('--javascripts-dir', opts.javascript); }
   if (opts.force) { options.push('--force'); }
   options.push('--css-dir', opts.css);


### PR DESCRIPTION
This is a quick fix for passing --generated-images-path until passing of raw options is implemented.

Thanks
