### PR TITLE
fixed warning about which module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "jshint-stylish": "^1.0.0",
     "map-stream": "^0.1.0",
     "mocha": "^1.21.4",
-    "should": "^4.0.4",
-    "which": "^1.0.5"
+    "should": "^4.0.4"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
When I do `npm i` I get the following warning:

``` shell
npm WARN package.json Dependency 'which' exists in both dependencies and devDependencies, using 'which@^1.0.5' from dependencies
```

This PR fixes that. Assuming that `which` is also used in production.
