### PR TITLE
Making the compass command configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ One of: nested, expanded, compact, or compressed.
 
 PS. Current compass `0.12.4` version  doesn't support `--sourcemap` flag, please update sass and compass as the following version.
 
+#### command
+
+**default:** compile
+
+**description:** The compass command to execute. This makes it possible to e.g. run `compass watch`.
+
 ```
 * sass (3.3.3)
 * compass (1.0.0.alpha.19)

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -28,7 +28,8 @@ var PLUGIN_NAME = 'gulp-compass',
     time: false,
     sourcemap: false,
     boring: false,
-    force: false
+    force: false,
+    command: 'compile'
   },
   isArray = Array.isArray || function(obj) {
     return Object.prototype.toString.call(obj) === '[object Array]';
@@ -66,7 +67,7 @@ module.exports = function(file, opts, callback) {
   if (opts.bundle_exec) {
     options.push('exec', 'compass');
   }
-  options.push('compile');
+  options.push(opts.command);
   if (process.platform === 'win32') {
     options.push(opts.project.replace(/\\/g, '/'));
   } else {


### PR DESCRIPTION
This makes it possible to not only run "compass compile", but also e.g. "compass watch".