### PR TITLE
Added Compass watch capability

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -67,6 +67,10 @@ module.exports = function(file, opts, callback) {
     options.push(opts.project);
   }
   options.push(file_path);
+  
+  if (opts.task !== 'watch') {
+    options.push(file_path);
+  }
 
   // set compass setting
   if (opts.environment) { options.push('--environment', opts.environment); }

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -66,7 +66,6 @@ module.exports = function(file, opts, callback) {
   } else {
     options.push(opts.project);
   }
-  options.push(file_path);
   
   if (opts.task !== 'watch') {
     options.push(file_path);

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -60,7 +60,7 @@ module.exports = function(file, opts, callback) {
   if (opts.bundle_exec) {
     options.push('exec', 'compass');
   }
-  options.push('compile');
+  options.push(opts.task || 'compile');
   if (process.platform === 'win32') {
     options.push(opts.project.replace(/\\/g, '/'));
   } else {


### PR DESCRIPTION
The existing pull requests related to this feature do not work correctly as the file path of a target CSS file is pushed into the command line arguments when watching. My solution removes this parameter if using compass watch which allows it to function correctly.