### PR TITLE
Use a single compass instance for multiple files.

### DIFF
--- a/lib/callCounter.js
+++ b/lib/callCounter.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = function(pendingResponses, cb) {
+  var fire = function() {
+    cb();
+    cb = function(){};
+  };
+
+  if (pendingResponses < 1) {
+    fire();
+  }
+
+  return function(){
+    if ( --pendingResponses <= 0 ) {
+      fire();
+    }
+  };
+};

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -32,8 +32,17 @@ var PLUGIN_NAME = 'gulp-compass',
     task: 'compile'
   };
 
-module.exports = function(file, opts, callback) {
+module.exports = function(files, opts, callback) {
+  if ( 'string' === typeof files ) {
+    files = [files];
+  }
   opts = opts || {};
+
+  var filePaths = [],
+      pathsToCss = [],
+      file,
+      i,
+      len;
 
   for (var key in defaults) {
     if (opts[key] === undefined) {
@@ -41,10 +50,15 @@ module.exports = function(file, opts, callback) {
     }
   }
 
-  var compassExecutable = 'compass',
-    file_path = file.replace(/\\/g, '/'),
-    relPathToSass = path.relative(path.resolve(opts.project, opts.sass), file),
-    pathToCss = path.resolve(opts.project, opts.css, gutil.replaceExtension(relPathToSass, '.css'));
+  for ( i = 0, len = files.length; i < len ; i++ ) {
+    file = files[i];
+    file = file.replace(/\\/g, '/');
+    filePaths.push(file);
+    var relPathToSass = path.relative(path.resolve(opts.project, opts.sass), file);
+    pathsToCss.push(path.resolve(opts.project, opts.css, gutil.replaceExtension(relPathToSass, '.css')));
+  }
+
+  var compassExecutable = 'compass';
 
   // check command exist
   if (opts.bundle_exec) {
@@ -69,7 +83,9 @@ module.exports = function(file, opts, callback) {
   }
 
   if (opts.task !== 'watch') {
-    options.push(file_path);
+    for ( i = 0, len = filePaths.length; i < len ; i++ ) {
+      options.push(filePaths[i]);
+    }
   }
 
   // set compass setting
@@ -103,7 +119,7 @@ module.exports = function(file, opts, callback) {
   if (opts.load_all) { options.push('--load-all', opts.load_all); }
   if (opts.require) {
     if (helpers.isArray(opts.require)) {
-      for (var i = 0, len = opts.require.length; i < len; i++) {
+      for (i = 0, len = opts.require.length; i < len; i++) {
         options.push('--require', opts.require[i]);
       }
     } else {
@@ -137,7 +153,7 @@ module.exports = function(file, opts, callback) {
   // support callback
   child.on('close', function(code) {
     if(callback){
-      callback(code, stdout, stderr, pathToCss, opts);
+      callback(code, stdout, stderr, pathsToCss, opts);
     }
   });
 };

--- a/lib/compass.js
+++ b/lib/compass.js
@@ -39,10 +39,7 @@ module.exports = function(files, opts, callback) {
   opts = opts || {};
 
   var filePaths = [],
-      pathsToCss = [],
-      file,
-      i,
-      len;
+      pathsToCss = [];
 
   for (var key in defaults) {
     if (opts[key] === undefined) {
@@ -50,13 +47,12 @@ module.exports = function(files, opts, callback) {
     }
   }
 
-  for ( i = 0, len = files.length; i < len ; i++ ) {
-    file = files[i];
+  files.forEach(function(file) {
     file = file.replace(/\\/g, '/');
-    filePaths.push(file);
     var relPathToSass = path.relative(path.resolve(opts.project, opts.sass), file);
     pathsToCss.push(path.resolve(opts.project, opts.css, gutil.replaceExtension(relPathToSass, '.css')));
-  }
+    filePaths.push(file);
+  });
 
   var compassExecutable = 'compass';
 
@@ -83,9 +79,9 @@ module.exports = function(files, opts, callback) {
   }
 
   if (opts.task !== 'watch') {
-    for ( i = 0, len = filePaths.length; i < len ; i++ ) {
-      options.push(filePaths[i]);
-    }
+    filePaths.forEach(function(file){
+      options.push(file);
+    });
   }
 
   // set compass setting
@@ -119,9 +115,9 @@ module.exports = function(files, opts, callback) {
   if (opts.load_all) { options.push('--load-all', opts.load_all); }
   if (opts.require) {
     if (helpers.isArray(opts.require)) {
-      for (i = 0, len = opts.require.length; i < len; i++) {
-        options.push('--require', opts.require[i]);
-      }
+      opts.require.forEach(function(f) {
+        options.push('--require', f);
+      });
     } else {
       options.push('--require', opts.require);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,10 @@ var fs = require('fs'),
 var PLUGIN_NAME = 'gulp-compass';
 
 module.exports = function(opt) {
-  var compile = function(file, enc, cb) {
+  var files = [],
+      fileNames = [];
+
+  var collectNames = function(file, enc, cb) {
     if (file.isNull()) {
       return cb(null, file);
     }
@@ -23,7 +26,14 @@ module.exports = function(opt) {
       return cb();
     }
 
-    compass(file.path, opt, function(code, stdout, stderr, pathToCss, options) {
+    files.push(file);
+    fileNames.push(file.path);
+    cb();
+  };
+
+  var compile = function(cb) {
+    var self = this;
+    compass(fileNames, opt, function(code, stdout, stderr, pathsToCss, options) {
       if (code === 127) {
         return cb(new gutil.PluginError(PLUGIN_NAME, 'You need to have Ruby and Compass installed ' +
           'and in your system PATH for this task to work.'));
@@ -31,27 +41,40 @@ module.exports = function(opt) {
 
       // support error callback
       if (code !== 0) {
-        return cb(new gutil.PluginError(PLUGIN_NAME, stdout || 'Compass failed', {fileName: file.path}));
+        return cb(new gutil.PluginError(PLUGIN_NAME, stdout || 'Compass failed'));
       }
 
-      file.contents = null;
-      file.path = gutil.replaceExtension(file.path, '.css');
+      var i,
+          processed = 0;
 
-      fs.readFile(pathToCss, function (err, contents) {
-        if (err) {
-          return cb(new gutil.PluginError(PLUGIN_NAME, 'Failure reading in the CSS output file'));
-        }
+      var readFileAndPush = function(file, pathToCss) {
+        file.contents = null;
+        file.path = pathToCss;
 
-        // Fix garbled output.
-        if (!(contents instanceof Buffer)) {
-          contents = new Buffer(contents);
-        }
+        fs.readFile(file.path, function (err, contents) {
+          if (err) {
+            return cb(new gutil.PluginError(PLUGIN_NAME, 'Failure reading in the CSS output file'));
+          }
 
-        file.contents = contents;
-        return cb(null, file);
-      });
+          // Fix garbled output.
+          if (!(contents instanceof Buffer)) {
+            contents = new Buffer(contents);
+          }
+
+          file.contents = contents;
+          self.push(file);
+          processed++;
+          if(processed === files.length) {
+            cb();
+          }
+        });
+      };
+
+      for ( i = 0; i < files.length ; i++ ) {
+        readFileAndPush(files[i], pathsToCss[i]);
+      }
     });
   };
 
-  return through.obj(compile);
+  return through.obj(collectNames, compile);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs'),
   compass = require('./compass'),
+  callCounter = require('./callCounter'),
   through = require('through2'),
   gutil = require('gulp-util'),
   path = require('path');
@@ -10,8 +11,7 @@ var fs = require('fs'),
 var PLUGIN_NAME = 'gulp-compass';
 
 module.exports = function(opt) {
-  var files = [],
-      fileNames = [];
+  var files = [];
 
   var collectNames = function(file, enc, cb) {
     if (file.isNull()) {
@@ -22,17 +22,41 @@ module.exports = function(opt) {
       return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
     }
 
-    if (path.basename(file.path)[0] === '_') {
-      return cb();
+    if (path.basename(file.path)[0] !== '_') {
+      files.push(file);
     }
 
-    files.push(file);
-    fileNames.push(file.path);
-    cb();
+    return cb();
+  };
+
+  var readFileAndPush = function(pathToCss, outputStream, cb) {
+    // Read each generated file so it can continue being streamed.
+    fs.readFile(pathToCss, function (err, contents) {
+      if (err) {
+        return cb(new gutil.PluginError(PLUGIN_NAME, 'Failure reading in the CSS output file'));
+      }
+
+      // Fix garbled output.
+      if (!(contents instanceof Buffer)) {
+        contents = new Buffer(contents);
+      }
+
+      outputStream.push(new gutil.File({
+        base: opt.css,
+        path: pathToCss,
+        contents: contents
+      }));
+
+      cb();
+    });
   };
 
   var compile = function(cb) {
-    var self = this;
+    var outputStream = this;
+    var fileNames = files.map(function(f){
+      return f.path;
+    });
+
     compass(fileNames, opt, function(code, stdout, stderr, pathsToCss, options) {
       if (code === 127) {
         return cb(new gutil.PluginError(PLUGIN_NAME, 'You need to have Ruby and Compass installed ' +
@@ -44,35 +68,10 @@ module.exports = function(opt) {
         return cb(new gutil.PluginError(PLUGIN_NAME, stdout || 'Compass failed'));
       }
 
-      var i,
-          processed = 0;
-
-      var readFileAndPush = function(file, pathToCss) {
-        file.contents = null;
-        file.path = pathToCss;
-
-        fs.readFile(file.path, function (err, contents) {
-          if (err) {
-            return cb(new gutil.PluginError(PLUGIN_NAME, 'Failure reading in the CSS output file'));
-          }
-
-          // Fix garbled output.
-          if (!(contents instanceof Buffer)) {
-            contents = new Buffer(contents);
-          }
-
-          file.contents = contents;
-          self.push(file);
-          processed++;
-          if(processed === files.length) {
-            cb();
-          }
-        });
-      };
-
-      for ( i = 0; i < files.length ; i++ ) {
-        readFileAndPush(files[i], pathsToCss[i]);
-      }
+      cb = callCounter(files.length, cb);
+      pathsToCss.forEach(function(f){
+        readFileAndPush(f, outputStream, cb);
+      });
     });
   };
 

--- a/test/callCounter_test.js
+++ b/test/callCounter_test.js
@@ -1,0 +1,43 @@
+'use strict';
+var callCounter = require('../lib/callCounter');
+
+require('mocha');
+require('should');
+
+describe('callCounter', function() {
+  it('calls the callback when no calls are expected', function() {
+    var called = 0;
+    callCounter(0, function(){ called++; });
+    called.should.eql(1);
+  });
+
+  it('calls the callback when the count is reached', function() {
+    var called = 0;
+    var counter = callCounter(3, function(){ called++; });
+    called.should.eql(0);
+    counter();
+    called.should.eql(0);
+    counter();
+    called.should.eql(0);
+    counter();
+    called.should.eql(1);
+  });
+
+  it('does not call the callback again if the limit is passed', function() {
+    var called = 0;
+    var counter = callCounter(1, function(){ called++; });
+    called.should.eql(0);
+    counter();
+    called.should.eql(1);
+    counter();
+    called.should.eql(1);
+  });
+
+  it('does not call the callback again if the 0 limit is passed', function() {
+    var called = 0;
+    var counter = callCounter(0, function(){ called++; });
+    called.should.eql(1);
+    counter();
+    called.should.eql(1);
+  });
+});

--- a/test/compass_test.js
+++ b/test/compass_test.js
@@ -38,9 +38,30 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path) {
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/compile.css');
+        new_path.should.eql([__dirname + '/css/compile.css']);
         actual = read_file(path.join(__dirname, 'css/compile.css'));
         expected = read_file(path.join(__dirname, 'expected/compile.css'));
+        actual.should.equal(expected);
+        done();
+      });
+    });
+
+    it('compile multiple scss to multiple css', function(done) {
+      compass([path.join(__dirname, 'sass/compile.scss'), path.join(__dirname, 'sass/simple.sass')], {
+        project: __dirname,
+        style: 'compressed',
+        css: 'css',
+        sass: 'sass',
+        logging: false
+      }, function(code, stdout, stderr, new_path) {
+        code.should.be.equal(0);
+        stderr.should.be.empty;
+        new_path.should.eql([__dirname + '/css/compile.css', __dirname + '/css/simple.css']);
+        actual = read_file(path.join(__dirname, 'css/compile.css'));
+        expected = read_file(path.join(__dirname, 'expected/compile.css'));
+        actual.should.equal(expected);
+        actual = read_file(path.join(__dirname, 'css/simple.css'));
+        expected = read_file(path.join(__dirname, 'expected/simple.css'));
         actual.should.equal(expected);
         done();
       });
@@ -56,7 +77,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/simple.css');
+        new_path.should.eql([__dirname + '/css/simple.css']);
         actual = read_file(path.join(__dirname, 'css/simple.css'));
         expected = read_file(path.join(__dirname, 'expected/simple.css'));
         actual.should.equal(expected);
@@ -71,7 +92,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/base/compile.css');
+        new_path.should.eql([__dirname + '/css/base/compile.css']);
         actual = read_file(path.join(__dirname, 'css/base/compile.css'));
         expected = read_file(path.join(__dirname, 'expected/compile.css'));
         actual.should.equal(expected);
@@ -87,7 +108,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/import.css');
+        new_path.should.eql([__dirname + '/css/import.css']);
         actual = read_file(path.join(__dirname, 'css/import.css'));
         expected = read_file(path.join(__dirname, 'expected/import.css'));
         actual.should.equal(expected);
@@ -103,7 +124,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/import2.css');
+        new_path.should.eql([__dirname + '/css/import2.css']);
         actual = read_file(path.join(__dirname, 'css/import2.css'));
         expected = read_file(path.join(__dirname, 'expected/import2.css'));
         actual.should.equal(expected);
@@ -119,7 +140,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/require.css');
+        new_path.should.eql([__dirname + '/css/require.css']);
         actual = read_file(path.join(__dirname, 'css/require.css'));
         expected = read_file(path.join(__dirname, 'expected/require.css'));
         actual.should.equal(expected);
@@ -138,7 +159,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/spriting.css');
+        new_path.should.eql([__dirname + '/css/spriting.css']);
         actual = read_file(path.join(__dirname, 'css/spriting.css'));
         expected = read_file(path.join(__dirname, 'expected/spriting.css'));
         actual.should.equal(expected);
@@ -154,7 +175,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/multiple-require.css');
+        new_path.should.eql([__dirname + '/css/multiple-require.css']);
         actual = read_file(path.join(__dirname, 'css/multiple-require.css'));
         expected = read_file(path.join(__dirname, 'expected/require.css'));
         actual.should.equal(expected);
@@ -170,7 +191,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/base/compile2.css');
+        new_path.should.eql([__dirname + '/css/base/compile2.css']);
         actual = read_file(path.join(__dirname, 'css/base/compile2.css'));
         expected = read_file(path.join(__dirname, 'expected/compile2.css'));
         actual.should.equal(expected);
@@ -186,7 +207,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path){
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/base/compile3.css');
+        new_path.should.eql([__dirname + '/css/base/compile3.css']);
         actual = read_file(path.join(__dirname, 'css/base/compile3.css'));
         expected = read_file(path.join(__dirname, 'expected/compile2.css'));
         actual.should.equal(expected);
@@ -203,7 +224,7 @@ describe('gulp-compass plugin', function() {
       }, function(code, stdout, stderr, new_path) {
         code.should.be.equal(0);
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/simple.css');
+        new_path.should.eql([__dirname + '/css/simple.css']);
         actual = read_file(path.join(__dirname, 'css/simple.css'));
         expected = read_file(path.join(__dirname, 'expected/simple.css'));
         actual.should.equal(expected);
@@ -219,7 +240,7 @@ describe('gulp-compass plugin', function() {
         logging: true
       }, function(code, stdout, stderr, new_path) {
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/simple2.css');
+        new_path.should.eql([__dirname + '/css/simple2.css']);
         done();
       });
     });
@@ -237,7 +258,7 @@ describe('gulp-compass plugin', function() {
         code.should.be.equal(0);
         options.debug.should.be.ok;
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/partial.css');
+        new_path.should.eql([__dirname + '/css/partial.css']);
         actual = read_file(path.join(__dirname, 'css/partial.css'));
         expected = read_file(path.join(__dirname, 'expected/partial.css'));
         actual.should.equal(expected);
@@ -273,7 +294,7 @@ describe('gulp-compass plugin', function() {
         code.should.be.equal(0);
         options.debug.should.be.ok;
         stderr.should.be.empty;
-        new_path.should.equal(__dirname + '/css/compile.css');
+        new_path.should.eql([__dirname + '/css/compile.css']);
         actual = read_file(path.join(__dirname, 'css/compile.css'));
         expected = read_file(path.join(__dirname, 'expected/compile.css'));
         actual.should.equal(expected);


### PR DESCRIPTION
So this is possibly a bit of a radical change of approach, so asking for feedback more than a quick merge.

The overhead of starting up the Ruby vm, and initialising compass for each file that needed building was causing a 'nothing to be done' build for 10 or so output files to take over 30s, actually generating the CSS would take around 15s more.

The change will use the input pipeline to just get filenames, and then only shell out to compass once all the file names have been listed. This allows us to pass all the files to compass, and let it do it's thing on mass.

With this change it's down to < 5s for the nothing to be done version, and < 20s for an actual build.

If the idea is sound, I'll take some more time to get the code up to scratch (there's some definite mess in there).

Thanks!