### PR TITLE
Ordered file push

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,9 +69,16 @@ module.exports = function(opt) {
       }
 
       cb = callCounter(files.length, cb);
-      pathsToCss.forEach(function(f) {
-        readFileAndPush(f, _this, cb);
-      });
+      var f = 0;
+      var next = function() {
+        readFileAndPush(pathsToCss[f], _this, function() {
+          cb();
+          if(pathsToCss.length > f)
+            next();
+        });
+        f++;
+      };
+      next();
     });
   };
 


### PR DESCRIPTION
Style order is important when concating styles. Using fs.readFile there is no guarantee that files will be read in requested order.