### PR TITLE
Fix sass files location issue

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -52,7 +52,7 @@ module.exports = function(files, opts, callback) {
     file = file.replace(/\\/g, '/');
     var relPathToSass = path.relative(path.resolve(opts.project, opts.sass), file);
     pathsToCss.push(path.resolve(opts.project, opts.css, gutil.replaceExtension(relPathToSass, '.css')));
-    filePaths.push(file);
+    filePaths.push(path.relative(opts.project, file));
   });
 
   var compassExecutable = 'compass';


### PR DESCRIPTION
This fixes "Individual stylesheets must be in the sass directory." error, when you have compass project deeper than your gulpfile root.

Explanations:
https://github.com/appleboy/gulp-compass/issues/61#issuecomment-137358981