### PR TITLE
Disable relative default config

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -9,7 +9,7 @@ var helpers = require('./helpers');
 var defaults = {
   style: false,
   comments: false,
-  relative: true,
+  relative: false,
   css: 'css',
   sass: 'sass',
   image: false,


### PR DESCRIPTION
Normal compass configuration is relative disabled.

It's creates problems from migrating projects from Grunt (or standalone cli) with standard compass config.